### PR TITLE
fix: use correct path for Salt versions >= v3004

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       salt-versions: ${{ steps.get-salt-versions.outputs.salt-versions }}
     steps:
       - id: get-salt-versions
-        uses: dafyddj/get-salt-versions@v1
+        uses: dafyddj/get-salt-versions@v2
   test:
     name: Test this action
     needs: gsv

--- a/action.yml
+++ b/action.yml
@@ -14,4 +14,9 @@ runs:
       run: |
         Invoke-WebRequest -Uri https://winbootstrap.saltproject.io -OutFile bootstrap-salt.ps1
         & .\bootstrap-salt.ps1 -runservice false -version ${{ inputs.version }}
-        echo "C:\salt" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        if ([version]"${{ inputs.version }}.0" -ge [version]"3004.0") {
+            $saltPath = "C:\Program Files\Salt Project\Salt"
+        } else {
+            $saltPath = "C:\salt"
+        }
+        $saltPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append


### PR DESCRIPTION
The new default path Salt for commands is
"C:\Program Files\Salt Project\Salt"
