### PR TITLE
feat: switch to `exe` and print package version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,13 +33,12 @@ runs:
       working-directory: ${{ runner.temp }}
       run: |
         Invoke-WebRequest `
-          -Uri https://repo.saltproject.io/windows/Salt-Minion-${{ inputs.salt-version }}-Py3-AMD64.msi `
-          -OutFile salt.msi
-        # `msiexec` returns to the command line immediately after launch
+          -Uri https://repo.saltproject.io/windows/Salt-Minion-${{ inputs.salt-version }}-Py3-AMD64-Setup.exe `
+          -OutFile salt.exe
+        # The installer returns to the command line immediately after launch
         # so we MUST `-Wait` to ensure install finishes completely
-        Start-Process -Wait msiexec -ArgumentList `
-          /package,salt.msi,/quiet,/norestart,`
-          CONFIG_TYPE=Custom,CUSTOM_CONFIG=config
+        Start-Process -Wait salt.exe -ArgumentList `
+          /S,/custom-config=config
         if ([version]"${{ inputs.salt-version }}.0" -ge [version]"3004.0") {
             $saltPath = "C:\Program Files\Salt Project\Salt"
         } else {

--- a/action.yml
+++ b/action.yml
@@ -45,14 +45,23 @@ runs:
             $saltPath = "C:\salt"
         }
         $saltPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+        # Enable embedded quotes on next invocation of `pwsh`
+        # Mainstreamed in `7.3.0`
+        if ($PSVersionTable.PSVersion -lt [version]"7.3.0") {
+            Enable-ExperimentalFeature PSNativeCommandArgumentPassing
+        }
     - name: Test Salt installation
       shell: pwsh
       run: |
-        $process = Start-Process -PassThru -NoNewWindow salt-call -ArgumentList test.ping
-        $handle = $process.Handle # hold on to Exitcode https://stackoverflow.com/a/23797762
-        if ($process.WaitForExit(12000)) {
-            exit $process.ExitCode
-        } else {
-            $process.Kill($true)
-            exit 1
+        function Test-LastExitCode {
+            param ([int]$lec)
+            if ($lec) {
+                Write-Host ("::error title=Test Salt installation::Native process returned exit code: $lec")
+                exit 1
+            }
         }
+        $pkgsJson = salt-call --out=json pkg.list_pkgs
+        Test-LastExitCode($LASTEXITCODE)
+        $pkgsJson | jq 'to_entries|map(.value|with_entries(if (.key|test("Salt Minion")) then ({key: .key, value: .value}) else empty end))'
+        Test-LastExitCode($LASTEXITCODE)


### PR DESCRIPTION
- feat: install Nullsoft EXE for better version number consistency
- feat: test for success by printing the Windows-registered package version
