### PR TITLE
fix: migrate download repo to `packages.broadcom.com`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         salt-version:
           - ${{ fromJSON(needs.gsv.outputs.salt-versions-els) }}
           - ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
-          - 3007.0rc1
+          # Skip RC testing for now- 3007.0rc1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run this action

--- a/action.yml
+++ b/action.yml
@@ -33,15 +33,24 @@ runs:
       working-directory: ${{ runner.temp }}
       run: |
         $version = "${{ inputs.salt-version }}"
+
         $rcDir = $version.Contains("rc") ? "salt_rc/" : ""
+        $repoDomain = "packages.broadcom.com"
+
         $simpleVersion = $version -replace '(\d+\.\d+)rc\d+', '$1'
         if ([version]$simpleVersion -ge [version]"3006.0") {
-            $repoDir = "${rcDir}salt/py3/windows/minor/$version"
+            $repoDir = "artifactory/saltproject-generic/windows/${version}"
+        } elseif ([version]$simpleVersion -eq [version]"3005.5") {
+            $repoDomain = "www.dropbox.com"
+            $repoDir = "scl/fi/c9526kgslr7qgfl6gllgj"
+            $params = "?rlkey=zj1ztrsjjmzuna6rslnv35ski&st=pk1dudf3&dl=1"
         } else {
-            $repoDir = "${rcDir}windows"
+            Write-Host ("::error title=Setup Salt installation::Versions before v3005.5 are NOT supported")
+            exit 1
         }
+
         Invoke-WebRequest `
-          -Uri https://repo.saltproject.io/${repoDir}/Salt-Minion-${{ inputs.salt-version }}-Py3-AMD64-Setup.exe `
+          -Uri https://${repoDomain}/${repoDir}/Salt-Minion-${version}-Py3-AMD64-Setup.exe${params} `
           -OutFile salt.exe
         # The installer returns to the command line immediately after launch
         # so we MUST `-Wait` to ensure install finishes completely


### PR DESCRIPTION
BREAKING CHANGE: Salt versions before v3005.5 are NOT supported

Fixes #58 
